### PR TITLE
vfs: persist posix metadata

### DIFF
--- a/docs/content/commands/rclone_mount.md
+++ b/docs/content/commands/rclone_mount.md
@@ -941,6 +941,15 @@ is an error reading the metadata the error will be returned as
 
 
 
+## POSIX metadata overlay (sidecar)
+
+Enable a best-effort POSIX attribute overlay on mounts with `--vfs-persist-metadata`. When enabled, chmod/chown/touch operations persist to a JSON sidecar file so they survive remounts on non-POSIX backends (e.g. WebDAV). The backend’s ACLs/ownership are not modified.
+
+- Enable with `--vfs-persist-metadata`.
+- Select the storage backend via `--vfs-metadata-store` (`backend`, `sidecar`, or `auto`).
+- Configure the sidecar extension with `--vfs-metadata-extension`; it defaults to `.metadata` when persistence is enabled and the store is not `backend`.
+- Metadata overlays apply after the backend’s attributes and failures are logged at debug level; FUSE operations continue even if metadata persistence fails. The overlay is independent of the `--metadata` listing feature.
+
 ```
 rclone mount remote:path /path/to/mountpoint [flags]
 ```
@@ -991,6 +1000,8 @@ rclone mount remote:path /path/to/mountpoint [flags]
       --vfs-fast-fingerprint                   Use fast (less accurate) fingerprints for change detection
       --vfs-links                              Translate symlinks to/from regular files with a '.rclonelink' extension for the VFS
       --vfs-metadata-extension string          Set the extension to read metadata from
+      --vfs-metadata-store string              Backend used for metadata persistence (default auto)
+      --vfs-persist-metadata                   Persist POSIX metadata for files
       --vfs-read-ahead SizeSuffix              Extra read ahead over --buffer-size when using cache-mode full
       --vfs-read-chunk-size SizeSuffix         Read the source objects in chunks (default 128Mi)
       --vfs-read-chunk-size-limit SizeSuffix   If greater than --vfs-read-chunk-size, double the chunk size after each chunk read, until the limit is reached ('off' is unlimited) (default off)

--- a/docs/content/commands/rclone_nfsmount.md
+++ b/docs/content/commands/rclone_nfsmount.md
@@ -946,6 +946,15 @@ is an error reading the metadata the error will be returned as
 rclone nfsmount remote:path /path/to/mountpoint [flags]
 ```
 
+## POSIX metadata overlay (sidecar)
+
+Enable a best-effort POSIX attribute overlay on NFS mounts with `--vfs-persist-metadata`. When enabled, chmod/chown/touch operations persist to a JSON sidecar file so they survive remounts on non-POSIX backends. The backend’s ACLs/ownership are not modified.
+
+- Enable with `--vfs-persist-metadata`.
+- Select the storage backend via `--vfs-metadata-store` (`backend`, `sidecar`, or `auto`).
+- Configure the sidecar extension with `--vfs-metadata-extension`; it defaults to `.metadata` when persistence is enabled and the store is not `backend`.
+- Metadata overlays apply after the backend’s attributes and failures are logged at debug level; NFS operations continue even if metadata persistence fails. The overlay is independent of the `--metadata` listing feature.
+
 ## Options
 
 ```
@@ -997,6 +1006,8 @@ rclone nfsmount remote:path /path/to/mountpoint [flags]
       --vfs-fast-fingerprint                   Use fast (less accurate) fingerprints for change detection
       --vfs-links                              Translate symlinks to/from regular files with a '.rclonelink' extension for the VFS
       --vfs-metadata-extension string          Set the extension to read metadata from
+      --vfs-metadata-store string              Backend used for metadata persistence (default auto)
+      --vfs-persist-metadata                   Persist POSIX metadata for files
       --vfs-read-ahead SizeSuffix              Extra read ahead over --buffer-size when using cache-mode full
       --vfs-read-chunk-size SizeSuffix         Read the source objects in chunks (default 128Mi)
       --vfs-read-chunk-size-limit SizeSuffix   If greater than --vfs-read-chunk-size, double the chunk size after each chunk read, until the limit is reached ('off' is unlimited) (default off)

--- a/vfs/metadata_backend.go
+++ b/vfs/metadata_backend.go
@@ -1,0 +1,119 @@
+package vfs
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/vfs/vfsmeta"
+)
+
+type backendStore struct {
+	vfs *VFS
+}
+
+func newBackendStore(vfs *VFS) *backendStore {
+	return &backendStore{vfs: vfs}
+}
+
+func (s *backendStore) Load(ctx context.Context, p string, isDir bool) (vfsmeta.Meta, error) {
+	entry, err := s.entry(ctx, p)
+	if err != nil {
+		return vfsmeta.Meta{}, err
+	}
+	md, err := fs.GetMetadata(ctx, entry)
+	if err != nil {
+		return vfsmeta.Meta{}, err
+	}
+	var m vfsmeta.Meta
+	if v, ok := md["mode"]; ok {
+		if n, err := strconv.ParseUint(v, 8, 32); err == nil {
+			u := uint32(n)
+			m.Mode = &u
+		}
+	}
+	if v, ok := md["uid"]; ok {
+		if n, err := strconv.ParseUint(v, 10, 32); err == nil {
+			u := uint32(n)
+			m.UID = &u
+		}
+	}
+	if v, ok := md["gid"]; ok {
+		if n, err := strconv.ParseUint(v, 10, 32); err == nil {
+			u := uint32(n)
+			m.GID = &u
+		}
+	}
+	if v, ok := md["mtime"]; ok {
+		if t, err := time.Parse(time.RFC3339Nano, v); err == nil {
+			m.Mtime = &t
+		}
+	}
+	if v, ok := md["atime"]; ok {
+		if t, err := time.Parse(time.RFC3339Nano, v); err == nil {
+			m.Atime = &t
+		}
+	}
+	if v, ok := md["btime"]; ok {
+		if t, err := time.Parse(time.RFC3339Nano, v); err == nil {
+			m.Btime = &t
+		}
+	}
+	return m, nil
+}
+
+func (s *backendStore) Save(ctx context.Context, p string, isDir bool, m vfsmeta.Meta) error {
+	entry, err := s.entry(ctx, p)
+	if err != nil {
+		return err
+	}
+	md, _ := fs.GetMetadata(ctx, entry)
+	if md == nil {
+		md = fs.Metadata{}
+	}
+	if m.Mode != nil {
+		md["mode"] = fmt.Sprintf("%o", *m.Mode)
+	}
+	if m.UID != nil {
+		md["uid"] = fmt.Sprintf("%d", *m.UID)
+	}
+	if m.GID != nil {
+		md["gid"] = fmt.Sprintf("%d", *m.GID)
+	}
+	if m.Mtime != nil {
+		md["mtime"] = m.Mtime.Format(time.RFC3339Nano)
+	}
+	if m.Atime != nil {
+		md["atime"] = m.Atime.Format(time.RFC3339Nano)
+	}
+	if m.Btime != nil {
+		md["btime"] = m.Btime.Format(time.RFC3339Nano)
+	}
+	w, ok := entry.(fs.SetMetadataer)
+	if !ok {
+		return fs.ErrorNotImplemented
+	}
+	return w.SetMetadata(ctx, md)
+}
+
+func (s *backendStore) Rename(ctx context.Context, oldPath, newPath string, isDir bool) error {
+	return nil
+}
+
+func (s *backendStore) Delete(ctx context.Context, p string, isDir bool) error {
+	return nil
+}
+
+func (s *backendStore) entry(ctx context.Context, p string) (fs.DirEntry, error) {
+	node, err := s.vfs.Stat(p)
+	if err != nil {
+		return nil, err
+	}
+	e := node.DirEntry()
+	if e == nil {
+		return nil, fs.ErrorObjectNotFound
+	}
+	return e, nil
+}

--- a/vfs/metadata_sidecar.go
+++ b/vfs/metadata_sidecar.go
@@ -1,0 +1,210 @@
+package vfs
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/vfs/vfsmeta"
+)
+
+type sidecarStore struct {
+	vfs *VFS
+	ext string
+}
+
+func newSidecarStore(vfs *VFS, ext string) *sidecarStore {
+	return &sidecarStore{vfs: vfs, ext: ext}
+}
+
+func (s *sidecarStore) name(p string) string {
+	return strings.TrimSuffix(p, "/") + s.ext
+}
+
+func (s *sidecarStore) Load(ctx context.Context, p string, isDir bool) (vfsmeta.Meta, error) {
+	b, err := s.vfs.ReadFile(s.name(p))
+	if err != nil {
+		return vfsmeta.Meta{}, err
+	}
+	meta, err := decodeSidecar(b)
+	if err != nil {
+		return vfsmeta.Meta{}, err
+	}
+	return meta, nil
+}
+
+func (s *sidecarStore) Save(ctx context.Context, p string, isDir bool, m vfsmeta.Meta) error {
+	cur, err := s.Load(ctx, p, isDir)
+	if err != nil {
+		if !errors.Is(err, fs.ErrorObjectNotFound) && !errors.Is(err, ENOENT) {
+			return err
+		}
+		cur = vfsmeta.Meta{}
+	}
+	cur.Merge(m)
+
+	b, err := encodeSidecar(cur)
+	if err != nil {
+		return err
+	}
+	name := s.name(p)
+	return s.writeWithFallback(name, b)
+}
+
+func (s *sidecarStore) Rename(ctx context.Context, oldPath, newPath string, isDir bool) error {
+	return s.vfs.Rename(s.name(oldPath), s.name(newPath))
+}
+
+func (s *sidecarStore) Delete(ctx context.Context, p string, isDir bool) error {
+	name := s.name(p)
+	if err := s.vfs.Remove(name); err != nil {
+		if errors.Is(err, ENOENT) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func (s *sidecarStore) renameSidecar(oldName, newName string) error {
+	oldDir, oldLeaf, err := s.vfs.StatParent(oldName)
+	if err != nil {
+		return err
+	}
+	newDir, newLeaf, err := s.vfs.StatParent(newName)
+	if err != nil {
+		return err
+	}
+	return oldDir.Rename(oldLeaf, newLeaf, newDir)
+}
+
+func (s *sidecarStore) writeAtomic(name string, data []byte) error {
+	tmp := name + ".tmp"
+	if err := s.vfs.WriteFile(tmp, data, 0o600); err != nil {
+		return err
+	}
+	if err := s.renameSidecar(tmp, name); err != nil {
+		_ = s.vfs.Remove(tmp)
+		return fmt.Errorf("rename sidecar metadata failed: %w", err)
+	}
+	return nil
+}
+
+func (s *sidecarStore) writeWithFallback(name string, data []byte) error {
+	if err := s.writeAtomic(name, data); err == nil {
+		return nil
+	} else if err != nil {
+		if err2 := s.vfs.WriteFile(name, data, 0o600); err2 != nil {
+			return fmt.Errorf("sidecar write fallback failed: %v (original error: %w)", err2, err)
+		}
+	}
+	return nil
+}
+
+func encodeSidecar(meta vfsmeta.Meta) ([]byte, error) {
+	type diskMeta struct {
+		Mode  *string `json:"mode,omitempty"`
+		UID   *string `json:"uid,omitempty"`
+		GID   *string `json:"gid,omitempty"`
+		Mtime *string `json:"mtime,omitempty"`
+		Atime *string `json:"atime,omitempty"`
+		Btime *string `json:"btime,omitempty"`
+	}
+	toUint := func(u *uint32) *string {
+		if u == nil {
+			return nil
+		}
+		s := strconv.FormatUint(uint64(*u), 10)
+		return &s
+	}
+	toTime := func(t *time.Time) *string {
+		if t == nil {
+			return nil
+		}
+		s := t.UTC().Format(time.RFC3339Nano)
+		return &s
+	}
+	d := diskMeta{
+		Mode:  toUint(meta.Mode),
+		UID:   toUint(meta.UID),
+		GID:   toUint(meta.GID),
+		Mtime: toTime(meta.Mtime),
+		Atime: toTime(meta.Atime),
+		Btime: toTime(meta.Btime),
+	}
+	return json.Marshal(d)
+}
+
+func decodeSidecar(data []byte) (vfsmeta.Meta, error) {
+	type diskMeta struct {
+		Mode  *string `json:"mode,omitempty"`
+		UID   *string `json:"uid,omitempty"`
+		GID   *string `json:"gid,omitempty"`
+		Mtime *string `json:"mtime,omitempty"`
+		Atime *string `json:"atime,omitempty"`
+		Btime *string `json:"btime,omitempty"`
+	}
+	var d diskMeta
+	if err := json.Unmarshal(data, &d); err != nil {
+		return vfsmeta.Meta{}, err
+	}
+	parseUint := func(s *string) (*uint32, error) {
+		if s == nil || *s == "" {
+			return nil, nil
+		}
+		val, err := strconv.ParseUint(*s, 10, 32)
+		if err != nil {
+			return nil, err
+		}
+		u := uint32(val)
+		return &u, nil
+	}
+	parseTime := func(s *string) (*time.Time, error) {
+		if s == nil || *s == "" {
+			return nil, nil
+		}
+		t, err := time.Parse(time.RFC3339Nano, *s)
+		if err != nil {
+			return nil, err
+		}
+		t = t.UTC()
+		return &t, nil
+	}
+	mode, err := parseUint(d.Mode)
+	if err != nil {
+		return vfsmeta.Meta{}, err
+	}
+	uid, err := parseUint(d.UID)
+	if err != nil {
+		return vfsmeta.Meta{}, err
+	}
+	gid, err := parseUint(d.GID)
+	if err != nil {
+		return vfsmeta.Meta{}, err
+	}
+	mtime, err := parseTime(d.Mtime)
+	if err != nil {
+		return vfsmeta.Meta{}, err
+	}
+	atime, err := parseTime(d.Atime)
+	if err != nil {
+		return vfsmeta.Meta{}, err
+	}
+	btime, err := parseTime(d.Btime)
+	if err != nil {
+		return vfsmeta.Meta{}, err
+	}
+	return vfsmeta.Meta{
+		Mode:  mode,
+		UID:   uid,
+		GID:   gid,
+		Mtime: mtime,
+		Atime: atime,
+		Btime: btime,
+	}, nil
+}

--- a/vfs/metadata_test.go
+++ b/vfs/metadata_test.go
@@ -1,0 +1,153 @@
+package vfs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/vfs/vfscommon"
+	"github.com/rclone/rclone/vfs/vfsmeta"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetadataSidecar(t *testing.T) {
+	ctx := context.Background()
+	opt := vfscommon.Opt
+	opt.PersistMetadata = "all"
+	opt.MetadataStore = "sidecar"
+	r, v := newTestVFSOpt(t, &opt)
+	defer r.Finalise()
+	r.WriteObject(ctx, "file", "", time.Now())
+	m := uint32(0o100600)
+	require.NoError(t, v.SaveMetadata(ctx, "file", false, vfsmeta.Meta{Mode: &m}))
+	got, err := v.LoadMetadata(ctx, "file", false)
+	require.NoError(t, err)
+	require.NotNil(t, got.Mode)
+	require.Equal(t, m, *got.Mode)
+
+	uid := uint32(1010)
+	require.NoError(t, v.SaveMetadata(ctx, "file", false, vfsmeta.Meta{UID: &uid}))
+	got, err = v.LoadMetadata(ctx, "file", false)
+	require.NoError(t, err)
+	require.NotNil(t, got.Mode)
+	require.Equal(t, m, *got.Mode)
+	require.NotNil(t, got.UID)
+	require.Equal(t, uid, *got.UID)
+}
+
+func TestMetadataSidecarMerge(t *testing.T) {
+	ctx := context.Background()
+	opt := vfscommon.Opt
+	opt.PersistMetadata = "all"
+	opt.MetadataStore = "sidecar"
+	r, v := newTestVFSOpt(t, &opt)
+	defer r.Finalise()
+
+	store := newSidecarStore(v, v.Opt.MetadataExtension)
+	mode := uint32(0o640)
+	require.NoError(t, store.Save(ctx, "standalone", false, vfsmeta.Meta{Mode: &mode}))
+	gid := uint32(2000)
+	require.NoError(t, store.Save(ctx, "standalone", false, vfsmeta.Meta{GID: &gid}))
+
+	got, err := store.Load(ctx, "standalone", false)
+	require.NoError(t, err)
+	require.NotNil(t, got.Mode)
+	require.Equal(t, mode, *got.Mode)
+	require.NotNil(t, got.GID)
+	require.Equal(t, gid, *got.GID)
+}
+
+func TestMetadataSidecarSkipsMetaPath(t *testing.T) {
+	ctx := context.Background()
+	opt := vfscommon.Opt
+	opt.PersistMetadata = "all"
+	opt.MetadataStore = "sidecar"
+	opt.MetadataExtension = ".metadata"
+	r, v := newTestVFSOpt(t, &opt)
+	defer r.Finalise()
+
+	r.WriteObject(ctx, "file", "", time.Now())
+
+	mode := uint32(0o600)
+	require.NoError(t, v.SaveMetadata(ctx, "file.metadata", false, vfsmeta.Meta{Mode: &mode}))
+
+	_, err := v.ReadFile("file.metadata.metadata")
+	require.Error(t, err)
+	require.ErrorIs(t, err, ENOENT)
+
+	_, err = v.LoadMetadata(ctx, "file.metadata", false)
+	require.Error(t, err)
+	require.ErrorIs(t, err, fs.ErrorObjectNotFound)
+}
+
+func TestMetadataSidecarFieldSelection(t *testing.T) {
+	ctx := context.Background()
+	opt := vfscommon.Opt
+	opt.PersistMetadata = "owner"
+	opt.MetadataStore = "sidecar"
+	r, v := newTestVFSOpt(t, &opt)
+	defer r.Finalise()
+
+	r.WriteObject(ctx, "file", "data", time.Now())
+	mode := uint32(0o644)
+	uid := uint32(1234)
+	meta := vfsmeta.Meta{Mode: &mode, UID: &uid}
+	require.NoError(t, v.SaveMetadata(ctx, "file", false, meta))
+
+	got, err := v.LoadMetadata(ctx, "file", false)
+	require.NoError(t, err)
+	require.Nil(t, got.Mode)
+	require.NotNil(t, got.UID)
+	require.Equal(t, uid, *got.UID)
+}
+
+func TestMetadataSidecarHiddenFromListing(t *testing.T) {
+	ctx := context.Background()
+	opt := vfscommon.Opt
+	opt.PersistMetadata = "all"
+	opt.MetadataStore = "sidecar"
+	opt.HideMetadata = true
+	r, v := newTestVFSOpt(t, &opt)
+	defer r.Finalise()
+
+	r.WriteObject(ctx, "file", "payload", time.Now())
+	mode := uint32(0o600)
+	require.NoError(t, v.SaveMetadata(ctx, "file", false, vfsmeta.Meta{Mode: &mode}))
+
+	entries, err := v.ReadDir("")
+	require.NoError(t, err)
+	ext := v.Opt.MetadataExtension
+	for _, entry := range entries {
+		require.NotEqual(t, "file"+ext, entry.Name())
+	}
+	content, err := v.ReadFile("file" + ext)
+	require.NoError(t, err)
+	require.Contains(t, string(content), "mode")
+}
+
+func TestMetadataSidecarVisibleWhenNotHidden(t *testing.T) {
+	ctx := context.Background()
+	opt := vfscommon.Opt
+	opt.PersistMetadata = "all"
+	opt.MetadataStore = "sidecar"
+	opt.HideMetadata = false
+	r, v := newTestVFSOpt(t, &opt)
+	defer r.Finalise()
+
+	r.WriteObject(ctx, "file", "payload", time.Now())
+	mode := uint32(0o600)
+	require.NoError(t, v.SaveMetadata(ctx, "file", false, vfsmeta.Meta{Mode: &mode}))
+
+	entries, err := v.ReadDir("")
+	require.NoError(t, err)
+	ext := v.Opt.MetadataExtension
+	found := false
+	for _, entry := range entries {
+		if entry.Name() == "file"+ext {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "expected metadata sidecar to be listed when hide flag disabled")
+}

--- a/vfs/vfsmeta/meta.go
+++ b/vfs/vfsmeta/meta.go
@@ -1,0 +1,48 @@
+// Package vfsmeta defines metadata structures and store interfaces
+// used by the VFS for persisting POSIX-like attributes.
+package vfsmeta
+
+import (
+	"context"
+	"time"
+)
+
+// Meta holds optional POSIX-like attributes.
+type Meta struct {
+	Mode  *uint32    `json:"mode,omitempty"`
+	UID   *uint32    `json:"uid,omitempty"`
+	GID   *uint32    `json:"gid,omitempty"`
+	Mtime *time.Time `json:"mtime,omitempty"`
+	Atime *time.Time `json:"atime,omitempty"`
+	Btime *time.Time `json:"btime,omitempty"`
+}
+
+// Merge overlays non-nil fields from d into m.
+func (m *Meta) Merge(d Meta) {
+	if d.Mode != nil {
+		m.Mode = d.Mode
+	}
+	if d.UID != nil {
+		m.UID = d.UID
+	}
+	if d.GID != nil {
+		m.GID = d.GID
+	}
+	if d.Mtime != nil {
+		m.Mtime = d.Mtime
+	}
+	if d.Atime != nil {
+		m.Atime = d.Atime
+	}
+	if d.Btime != nil {
+		m.Btime = d.Btime
+	}
+}
+
+// Store defines a metadata persistence backend.
+type Store interface {
+	Load(ctx context.Context, path string, isDir bool) (Meta, error)
+	Save(ctx context.Context, path string, isDir bool, m Meta) error
+	Rename(ctx context.Context, oldPath, newPath string, isDir bool) error
+	Delete(ctx context.Context, path string, isDir bool) error
+}


### PR DESCRIPTION
## Summary
- implement sidecar-based metadata store
- persist chmod/chown/touch via VFS and mount integration
- merge metadata updates with existing stored fields
- add backend metadata store
- select store based on --vfs-metadata-store and remote features
- invalidate FUSE attribute cache after saving metadata
- log metadata persistence failures in mount handlers
- build mount on macOS and BSD platforms
- add sidecar metadata persistence test

## Testing
- `go test ./vfs -run TestMetadataSidecar -count=1 -v`
- `go test ./vfs/... -run TestNonExisting`
- `go test ./cmd/mount/... -run TestNonExisting`
- `go test ./cmd/nfsmount/... -run TestNonExisting`


------
https://chatgpt.com/codex/tasks/task_e_68bbefeeb9f0832d8115c00a500907aa